### PR TITLE
Add a token for the Circle CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hyphenated
 
-[![CircleCI](https://circleci.com/gh/sergeysolovev/hyphenated.svg?style=shield)](https://circleci.com/gh/sergeysolovev/hyphenated)
+[![CircleCI](https://circleci.com/gh/sergeysolovev/hyphenated.svg?style=shield&circle-token=0701315b8c50b1291d10436e180526b252d7172c)](https://circleci.com/gh/sergeysolovev/hyphenated)
 
 Better hyphenation.
 


### PR DESCRIPTION
It won’t be necessary once the repo is public.